### PR TITLE
Enhanced GHA workflow to publish multi-version docs on gh-pages.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,14 @@
 name: Release and Publish Documentation
 
+concurrency:
+  group: release
+  cancel-in-progress: true
+  
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+  
 on:
   workflow_dispatch:
     inputs:
@@ -10,7 +19,6 @@ on:
   push:
     branches:
       - 'release/*'
-
 jobs:
   build-and-publish:
     name: Build and Publish Documentation
@@ -33,10 +41,19 @@ jobs:
             FULL_VERSION=${GITHUB_REF_NAME#release/}
             FULL_VERSION=${FULL_VERSION#v}
           fi
+          
+          # Validate version format
+          if ! [[ "$FULL_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Invalid version format: $FULL_VERSION"
+            exit 1
+          fi
+          
           MINOR_VERSION=$(echo "$FULL_VERSION" | cut -d. -f1,2)
+          echo "Final version: ${FULL_VERSION}"
+          echo "Minor version: ${MINOR_VERSION}"
           echo "version=${FULL_VERSION}" >> $GITHUB_OUTPUT
           echo "minor_version=${MINOR_VERSION}" >> $GITHUB_OUTPUT
-
+          
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
@@ -46,31 +63,60 @@ jobs:
       - name: Build website
         # We override baseURL so Hugo generates correct internal links for the subfolder
         run: |
-          hugo --minify --baseURL "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/manual/${{ steps.get_version.outputs.minor_version }}/"
+          hugo --minify --baseURL "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/manual/${{ steps.get_version.outputs.minor_version }}/" --destination public/manual/${{ steps.get_version.outputs.minor_version }}/
 
-      - name: Create Root Redirect
-        # This creates an index.html at the root that sends users to the latest version
+      - name: Generate versions.json and "latest" redirect
+        id: generate_manifest
         run: |
-          mkdir -p ./root_redirect
-          echo '<meta http-equiv="refresh" content="0; url=manual/${{ steps.get_version.outputs.minor_version }}/">' > ./root_redirect/index.html
+          # Create a temporary directory for the gh-pages clone
+          PAGES_DIR=./gh-pages-clone
+          git clone --branch gh-pages --single-branch "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" "$PAGES_DIR"
+
+          # Path to the documentation directory on the gh-pages branch
+          MANUAL_DIR="$PAGES_DIR/manual"
+          
+          # Ensure the target directories for our generated files exist in the build output
+          mkdir -p ./public/manual
+          mkdir -p ./public/manual/latest
+
+          # --- Part 1: Generate versions.json ---
+          # List existing version dirs, add the new version, sort unique descending, and format as JSON
+          VERSIONS=$( ( (test -d "$MANUAL_DIR" && ls -d "$MANUAL_DIR"/*/ | xargs -n 1 basename) || true; echo "${{ steps.get_version.outputs.minor_version }}" ) \
+            | grep -v "latest" \
+            | sort -rV | uniq )
+            
+          echo "Detected versions:"
+          echo "$VERSIONS"
+
+          echo "$VERSIONS" | jq -R . | jq -s . > ./public/manual/versions.json
+          
+          echo "Generated versions.json:"
+          cat ./public/manual/versions.json
+
+          # --- Part 2: Create the 'latest' redirect ---
+          # The latest version is the first line of our sorted list
+          LATEST_VERSION=$(echo "$VERSIONS" | head -n 1)
+          
+          if [ -z "$LATEST_VERSION" ]; then
+            echo "Error: Could not determine the latest version."
+            exit 1
+          fi
+
+          echo "The latest version is: $LATEST_VERSION"
+          echo "LATEST_VERSION=$LATEST_VERSION" >> $GITHUB_OUTPUT
+          
+          # Sync 404.html for automated redirection to latest version
+          cp ./404.html ./public
 
       - name: Publish Versioned Documentation
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
-          destination_dir: manual/${{ steps.get_version.outputs.minor_version }}
           keep_files: true # Essential: keeps /manual/1.0 when publishing 1.1
           user_name: 'github-actions[bot]'
           user_email: 'github-actions[bot]@users.noreply.github.com'
-          commit_message: 'docs: publish version ${{ steps.get_version.outputs.version }}'
-
-      - name: Publish Root Redirect
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./root_redirect
-          keep_files: true # Essential: prevents deleting the /manual directory
-          user_name: 'github-actions[bot]'
-          user_email: 'github-actions[bot]@users.noreply.github.com'
-          commit_message: 'docs: update root redirect to ${{ steps.get_version.outputs.minor_version }}'
+          commit_message: |
+            docs: publish website for ${{ steps.get_version.outputs.version }}
+            
+            - Update versions.json manifest

--- a/404.html
+++ b/404.html
@@ -91,11 +91,24 @@
     (async function() {
       const currentPath = window.location.pathname;
       const currentHash = window.location.hash;
+      let latestVersion = ''; 
       
-      let latestVersion = '';
+      // Find versions.json by traversing up the directory structure
+      let rootPath = currentPath;
+      do {
+        try {
+          const response = await fetch(`${rootPath}/manual/versions.json`, { method: 'HEAD' });
+          if (response.ok) {
+            break; // Found the versions.json, stop looking further up
+          }
+        } catch (error) {
+          // Ignore errors and continue looking up
+        }
+        rootPath = rootPath.substring(0, rootPath.lastIndexOf('/'));
+      } while (rootPath.length > 0);
 
       try {
-        const response = await fetch('/manual/versions.json');
+        let response = await fetch(`${rootPath}/manual/versions.json`);
         if (response.ok) {
           const versions = await response.json();
           if (Array.isArray(versions) && versions.length > 0) {
@@ -107,16 +120,16 @@
       }
 
       if (latestVersion) {
+        
         if (currentPath === '/') {
-          window.location.replace(`/manual/${latestVersion}/${currentHash}`);
+          window.location.replace(`${rootPath}/manual/${latestVersion}/${currentHash}`);
           return;
-        } else if (currentPath.startsWith('/manual/latest/')) {
-          const remainingPath = currentPath.substring('/manual/latest/'.length);
-          const targetUrl = `/manual/${latestVersion}/${remainingPath}${currentHash}`;
+        } else if (currentPath.search('/manual/latest/') >= 0) {
+          const targetUrl = currentPath.replace('/manual/latest/', `/manual/${latestVersion}/`) + currentHash;
           window.location.replace(targetUrl);
           return; // Stop execution, browser is redirecting
         } else {
-          document.getElementById('latest-link').href = `/manual/${latestVersion}/`;
+          document.getElementById('latest-link').href = `${rootPath}/manual/${latestVersion}/`;
         }
       } else {
         // Fallback in case versions.json cannot be loaded
@@ -124,7 +137,7 @@
           window.location.replace(`/manual/latest/${currentHash}`);
           return;
         }
-        document.getElementById('latest-link').href = '/manual/latest/'; 
+        document.getElementById('latest-link').href = `${rootPath}/manual/latest/`; 
       }
 
       // If we reach this point, it means no redirection happened


### PR DESCRIPTION
Fixed workflow to generate documentation with multi-versions support.

- Documentation is generated and published on gh-pages under /manual/_version_/*
- A registry of availble versions in /manual/versions.json is maintained to enable dynamic version selection.
- An automated redirection page (404.html) is provided to route requests to the latest version and to resolve references to /manual/latest/*.
