### PR TITLE
Db contrib / issue 36: add missing algolia meta tag to 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="algolia-site-verification"  content="7D377B04DA329B56" />
   <title>Page Not Found</title>
   <style>
     body {


### PR DESCRIPTION
The algolia-site-verification meta tag was added to the themes header.html for content pages, but was missing from 404.html .

The release workflow copies 404.html to the site root
- name: Generate versions.json and "latest" redirect
   id: generate_manifest
   run .....
          &nbsp; cp ./404.html ./public

so it serves sa the root redirect landing page, not just an error page. This means the root domain was not exposing the verification tag